### PR TITLE
perf(angular): use ngForTrackBy

### DIFF
--- a/angular/src/app/app.component.html
+++ b/angular/src/app/app.component.html
@@ -1,6 +1,6 @@
 <div class="pokemonList">
   <app-item
-    *ngFor="let id of itemIds"
+    *ngFor="let id of itemIds; trackBy: trackById"
     [id]="id"
     [searchQuery]="searchQuery"
   ></app-item>

--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -16,4 +16,12 @@ export class AppComponent {
     this.input = value;
     this.searchQuery = value.toLowerCase();
   }
+
+  /**
+   * Tell how to track changes of the collection to Angular.
+   * @see https://angular.jp/guide/built-in-directives#tracking-items-with-ngfor-trackby
+   */
+  trackById(index: number, itemId: string) {
+    return itemId;
+  }
 }


### PR DESCRIPTION
Angularの実装コードにおいて、 `ngFor` が `trackBy` を設定されずに使われていたため、一般的なプロダクションユースのコードと比べてパフォーマンスが低く出やすい状態であるのを改善しています。

https://angular.jp/guide/built-in-directives#tracking-items-with-ngfor-trackby

Reactの反復処理における `key` と意味論的にはほとんど等しく、Angularはその指定がなくてもデフォルトでいい感じに動こうとしますが、明示的に指定されるのとされないとでは実行時のパフォーマンスが大きく変わります。

TrackByを設定しないAngularのNgForによる反復レンダリングは、一般的にはTrackByをつけたAngularJSよりも遅く、パフォーマンスを多少でも意識するアプリケーションでこれを設定しないことはありえないと思われます。

手元のChromeでCPU4倍減速した結果ベンチマークは522msになりました

<img width="649" alt="image" src="https://user-images.githubusercontent.com/1529180/178674910-2afdc298-3e08-4cb0-9305-c499a0c10629.png">

